### PR TITLE
Fix issue with no set Day of Week

### DIFF
--- a/custom_components/chore_helper/chore_weekly.py
+++ b/custom_components/chore_helper/chore_weekly.py
@@ -40,7 +40,7 @@ class WeeklyChore(Chore):
         offset = -1
         if self._chore_day is not None:
             day_index = WEEKDAYS.index(self._chore_day)
-        else: # if chore day is not set, just repeat the start date's day
+        else:  # if chore day is not set, just repeat the start date's day
             day_index = start_date.weekday()
 
         if (week - start_week) % self._period == 0:  # Chore this week

--- a/custom_components/chore_helper/chore_weekly.py
+++ b/custom_components/chore_helper/chore_weekly.py
@@ -38,12 +38,15 @@ class WeeklyChore(Chore):
         week = day1.isocalendar()[1]
         weekday = day1.weekday()
         offset = -1
+        if self._chore_day is not None:
+            day_index = WEEKDAYS.index(self._chore_day)
+        else: # if chore day is not set, just repeat the start date's day
+            day_index = start_date.weekday()
+
         if (week - start_week) % self._period == 0:  # Chore this week
-            if self._chore_day is not None:
-                day_index = WEEKDAYS.index(self._chore_day)
-                if day_index >= weekday:  # Chore still did not happen
-                    offset = day_index - weekday
-        iterate_by_week = 7 - weekday + WEEKDAYS.index(self._chore_day)
+            if day_index >= weekday:  # Chore still did not happen
+                offset = day_index - weekday
+        iterate_by_week = 7 - weekday + day_index
         while offset == -1:  # look in following weeks
             candidate = day1 + relativedelta(days=iterate_by_week)
             week = candidate.isocalendar()[1]


### PR DESCRIPTION
The PR fixes an issue with the chore_weekly candidate selection.
Without the PR, if no weekday is set, it is used without checking if it is `None`, and likely doesn't select an appropriate date.
The PR checks if a chore day is set.  If it is, it uses it.  If not, it just uses the day of the week of the start_date (which I think corresponds to the last completed date).


I believe this should fix #32, but I welcome more testing / reviews.  
