### PR TITLE
Overdue Chores Fix

### DIFF
--- a/custom_components/chore_helper/__init__.py
+++ b/custom_components/chore_helper/__init__.py
@@ -102,7 +102,7 @@ ADD_REMOVE_TIME_SCHEMA = vol.Schema(
 OFFSET_DATE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_ENTITY_ID): vol.All(cv.ensure_list, [cv.string]),
-        vol.Required(const.CONF_DATE): cv.date,
+        vol.Optional(const.CONF_DATE): cv.date,
         vol.Required(const.CONF_OFFSET): vol.All(
             vol.Coerce(int), vol.Range(min=-31, max=31)
         ),

--- a/custom_components/chore_helper/chore.py
+++ b/custom_components/chore_helper/chore.py
@@ -338,7 +338,7 @@ class Chore(RestoreEntity):
 
     def chore_schedule(self) -> Generator[date, None, None]:
         """Get dates within configured date range."""
-        start_date: date = self._calculate_start_date() # 2024-02-28
+        start_date: date = self._calculate_start_date()
         for _ in range(int(self._forecast_dates) + 1):
             try:
                 next_due_date = self._find_candidate_date(start_date)
@@ -480,11 +480,8 @@ class Chore(RestoreEntity):
     def update_state(self) -> None:
         """Pick the first event from chore dates, update attributes."""
         LOGGER.debug("(%s) Looking for next chore date", self._attr_name)
-        # 29.02.2024 00:07
         self._last_updated = helpers.now()
-        # 29.02.2024
         today = self._last_updated.date()
-        # 06.03.2024
         self._next_due_date = self.get_next_due_date(self._calculate_start_date())
         if self._next_due_date is not None:
             LOGGER.debug(
@@ -554,6 +551,12 @@ class Chore(RestoreEntity):
             day1 = schedule_start_date
         today = helpers.now().date()
         if (
+            day1 == start_date
+            and self.last_completed is not None
+            and self.last_completed.date() == day1
+        ):
+            day1 = day1 + relativedelta(days=1)
+        if (
             day1 == today
             and self.last_completed is not None
             and self.last_completed.date() == today
@@ -583,11 +586,10 @@ class Chore(RestoreEntity):
     def _calculate_schedule_start_date(self) -> date:
         """Calculate start date for scheduling offsets."""
 
-        # after = self._frequency[:6] == "after-"
+        after = self._frequency[:6] == "after-"
         start_date = self._start_date
 
-        # if after and self.last_completed is not None:
-        if self.last_completed is not None:
+        if after and self.last_completed is not None:
             earliest_date = self._add_period_offset(self.last_completed.date())
 
             if earliest_date > start_date:

--- a/custom_components/chore_helper/chore.py
+++ b/custom_components/chore_helper/chore.py
@@ -338,7 +338,7 @@ class Chore(RestoreEntity):
 
     def chore_schedule(self) -> Generator[date, None, None]:
         """Get dates within configured date range."""
-        start_date: date = self._calculate_start_date()
+        start_date: date = self._calculate_start_date() # 2024-02-28
         for _ in range(int(self._forecast_dates) + 1):
             try:
                 next_due_date = self._find_candidate_date(start_date)
@@ -480,8 +480,11 @@ class Chore(RestoreEntity):
     def update_state(self) -> None:
         """Pick the first event from chore dates, update attributes."""
         LOGGER.debug("(%s) Looking for next chore date", self._attr_name)
+        # 29.02.2024 00:07
         self._last_updated = helpers.now()
+        # 29.02.2024
         today = self._last_updated.date()
+        # 06.03.2024
         self._next_due_date = self.get_next_due_date(self._calculate_start_date())
         if self._next_due_date is not None:
             LOGGER.debug(
@@ -580,10 +583,11 @@ class Chore(RestoreEntity):
     def _calculate_schedule_start_date(self) -> date:
         """Calculate start date for scheduling offsets."""
 
-        after = self._frequency[:6] == "after-"
+        # after = self._frequency[:6] == "after-"
         start_date = self._start_date
 
-        if after and self.last_completed is not None:
+        # if after and self.last_completed is not None:
+        if self.last_completed is not None:
             earliest_date = self._add_period_offset(self.last_completed.date())
 
             if earliest_date > start_date:

--- a/custom_components/chore_helper/chore_weekly.py
+++ b/custom_components/chore_helper/chore_weekly.py
@@ -42,7 +42,7 @@ class WeeklyChore(Chore):
             if self._chore_day is not None:
                 day_index = WEEKDAYS.index(self._chore_day)
                 if day_index >= weekday:  # Chore still did not happen
-                    offset = day_index - weekday # 5
+                    offset = day_index - weekday
         iterate_by_week = 7 - weekday + WEEKDAYS.index(self._chore_day)
         while offset == -1:  # look in following weeks
             candidate = day1 + relativedelta(days=iterate_by_week)

--- a/custom_components/chore_helper/chore_weekly.py
+++ b/custom_components/chore_helper/chore_weekly.py
@@ -30,19 +30,19 @@ class WeeklyChore(Chore):
     def _add_period_offset(self, start_date: date) -> date:
         return start_date + relativedelta(weeks=self._period)
 
-    def _find_candidate_date(self, day1: date) -> date | None:
+    def _find_candidate_date(self, day1: date) -> date | None: # 2024-02-26
         """Calculate possible date, for weekly frequency."""
-        start_date = self._calculate_schedule_start_date()
-        start_week = start_date.isocalendar()[1]
-        day1 = self.calculate_day1(day1, start_date)
-        week = day1.isocalendar()[1]
-        weekday = day1.weekday()
+        start_date = self._calculate_schedule_start_date() # 2024-02-27
+        start_week = start_date.isocalendar()[1] # 10
+        day1 = self.calculate_day1(day1, start_date) # 27
+        week = day1.isocalendar()[1] # 10
+        weekday = day1.weekday() # 1
         offset = -1
         if (week - start_week) % self._period == 0:  # Chore this week
             if self._chore_day is not None:
-                day_index = WEEKDAYS.index(self._chore_day)
+                day_index = WEEKDAYS.index(self._chore_day) # 6
                 if day_index >= weekday:  # Chore still did not happen
-                    offset = day_index - weekday
+                    offset = day_index - weekday # 5
         iterate_by_week = 7 - weekday + WEEKDAYS.index(self._chore_day)
         while offset == -1:  # look in following weeks
             candidate = day1 + relativedelta(days=iterate_by_week)

--- a/custom_components/chore_helper/chore_weekly.py
+++ b/custom_components/chore_helper/chore_weekly.py
@@ -30,17 +30,17 @@ class WeeklyChore(Chore):
     def _add_period_offset(self, start_date: date) -> date:
         return start_date + relativedelta(weeks=self._period)
 
-    def _find_candidate_date(self, day1: date) -> date | None: # 2024-02-26
+    def _find_candidate_date(self, day1: date) -> date | None:
         """Calculate possible date, for weekly frequency."""
-        start_date = self._calculate_schedule_start_date() # 2024-02-27
-        start_week = start_date.isocalendar()[1] # 10
-        day1 = self.calculate_day1(day1, start_date) # 27
-        week = day1.isocalendar()[1] # 10
-        weekday = day1.weekday() # 1
+        start_date = self._calculate_schedule_start_date()
+        start_week = start_date.isocalendar()[1]
+        day1 = self.calculate_day1(day1, start_date)
+        week = day1.isocalendar()[1]
+        weekday = day1.weekday()
         offset = -1
         if (week - start_week) % self._period == 0:  # Chore this week
             if self._chore_day is not None:
-                day_index = WEEKDAYS.index(self._chore_day) # 6
+                day_index = WEEKDAYS.index(self._chore_day)
                 if day_index >= weekday:  # Chore still did not happen
                     offset = day_index - weekday # 5
         iterate_by_week = 7 - weekday + WEEKDAYS.index(self._chore_day)


### PR DESCRIPTION
As requested in #33, this is my attempt to fix #33. It's been quite some time, but I think essentially `every` chores were bypassing a check in `calculate_day1`, because `today` is calculated past midnight. I've left the check in, because I had trouble understanding the complete flow and added an additional check for `day1 == start_date == last_completed`, which will just increment `day1`.

I would appreciate, if this can be double-checked, but I've used this implementation for ~10 months now and never encountered this issue again.